### PR TITLE
improvement: Fix IDEA cursor navigation line number issue and add -r parameter to reuse existing window

### DIFF
--- a/src/main/kotlin/com/github/qczone/switch2cursor/actions/OpenFileInCursorAction.kt
+++ b/src/main/kotlin/com/github/qczone/switch2cursor/actions/OpenFileInCursorAction.kt
@@ -36,7 +36,7 @@ class OpenFileInCursorAction : AnAction() {
                 arrayOf("open", "-a", "$cursorPath", "cursor://file$filePath:$line:$column")
             }
             System.getProperty("os.name").lowercase().contains("windows") -> {
-                arrayOf("cmd", "/c", "$cursorPath", "--goto", "$filePath:$line:$column")
+                arrayOf("cmd", "/c", "$cursorPath" , "-r", "--goto", "$filePath:$line:$column")
             }
             else -> {
                 arrayOf(cursorPath, "--goto", "$filePath:$line:$column")


### PR DESCRIPTION
What
This PR fixes an issue where the IntelliJ IDEA command-line launcher would open the correct file but fail to position the cursor at the specified line and column. It also adds the -r flag so that files and folders are opened in an existing IDEA window rather than spawning a new one.

Why
Opening a new window each time breaks workspace continuity and can degrade performance.

Changes
Updated the launcher invocation array to include -r before --goto